### PR TITLE
elgohr/Publish-Docker-Github-Action@master is deprecated

### DIFF
--- a/book/lectures/201-github_actions.qmd
+++ b/book/lectures/201-github_actions.qmd
@@ -140,7 +140,7 @@ Steps that use actions look like the one shown below (which builds and publishes
 
 ```yaml
 - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: myDocker/repository
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
Replaced by supported version. Thanks for using 🙂