### PR TITLE
Downgrading multimethod to prevent pandera error

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,3 +38,9 @@ jobs:
         uses: quarto-dev/quarto-actions/render@v2
         with:
           path: book
+      
+      - name: Upload rendered HTML
+        uses: actions/upload-artifact@v4
+        with:
+          name: quarto-html-preview
+          path: docs/

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pandera==0.21.0
 pytest
 pointblank
 polars
+multimethod==1.9.1


### PR DESCRIPTION
This might be a temporary fix, but the version of `pandera` we're using still relies on `multimethod`. In `pandera` v0.22, as compared to our v0.21, [they remove the dependency on `multimethod`](https://github.com/unionai-oss/pandera/releases/tag/v0.22.0).

It appears that the CI pipeline is installing `multimethod` version >= 2.0 [that has removed `overload`](https://github.com/coady/multimethod/releases) a function that `pandera` uses. 

Oddly, on my own machine when I install from `requirements.txt` I get `multimethod` v1.9.1, so the error doesn't appear on my machine. There must be some lag with conda-forge. 

At some point, we should update the version of pandera we're using. 